### PR TITLE
Change dependency to work on Raspberry Pi 3

### DIFF
--- a/Blinkt.js
+++ b/Blinkt.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var wpi = require('wiring-pi'),
+var wpi = require('wiringpi-node'),
 	DAT = 23,
 	CLK = 24,
 	Blinkt;

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "private": false,
   "dependencies": {
-    "wiring-pi": "2.1.1"
+    "wiringpi-node": "2.4.4"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
After struggling with "unable to determine hardware version" errors, I found that replacing this dependency enables node-blinkt to function once again on my Raspberry Pi 3. 

You may decide to accept or reject this, just an FYI. 

Thanks again for the module!