### PR TITLE
iotjs: Add index file and updated doc and helper scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,31 @@
 #!/bin/make -f
 # -*- makefile -*-
-main_src ?= example/fade.js
-iotjs_modules_dir ?= iotjs-modules
+
+default: help start
+	@echo "# $@: $^"
+
+main_src ?= dist/example/fade.js
+runtime ?= iotjs
+project?=node-blinkt
+
+iotjs_modules_dir ?= iotjs_modules
+iotjs_wiringpi_dir ?= ${iotjs_modules_dir}/iotjs-wiringpi
+iotjs_wiringpi_url ?= https://github.com/SamsungInternet/wiringpi-iotjs
+iotjs_wiringpi_revision ?= v0.0.1
+
+deploy_dir ?= ${CURDIR}/tmp/deploy
+deploy_modules_dir ?= ${deploy_dir}/iotjs_modules
+deploy_module_dir ?= ${deploy_modules_dir}/${project}
+deploy_srcs += ${deploy_module_dir}/dist/*.js
+deploy_srcs += ${deploy_module_dir}/dist/*/*.js
+deploy_srcs += ${deploy_module_dir}/index.js
+
+help:
+	@echo "Usage:"
+	@echo "# make start"
+
+cleanall:
+	rm -rf iotjs_modules node_modules
 
 run/node: ${main_src} node_modules
 	npm test
@@ -9,20 +33,30 @@ run/node: ${main_src} node_modules
 run/iotjs: ${main_src} ${iotjs_modules_dir}
 	-which iotjs
 	-iotjs -h 
-	IOTJS_EXTRA_MODULE_PATH=${iotjs_modules_dir}/iotjs-wiringpi/lib/iotjs iotjs $<
+	iotjs $<
 
 run: run/node run/iotjs
 
-iotjs_wiringpi_dir ?= ${iotjs_modules_dir}/iotjs-wiringpi
-iotjs_wiringpi_url ?= https://github.com/rzr/iotjs-wiringpi
-iotjs_wiringpi_branch ?= sandbox/rzr/master
-
-${iotjs_modules_dir}/iotjs-wiringpi:
+${iotjs_modules_dir}/wiringpi-node:
 	mkdir -p $@
-	git clone --depth 1 --recursive -b ${iotjs_wiringpi_branch} ${iotjs_wiringpi_url} $@
+	git clone --depth 1 --recursive -b ${iotjs_wiringpi_revision} ${iotjs_wiringpi_url} $@
 
-${iotjs_modules_dir}: ${iotjs_modules_dir}/iotjs-wiringpi
+${iotjs_modules_dir}: ${iotjs_modules_dir}/wiringpi-node
 	du -ks $@
 
 node_modules: package.json
-	npm install
+	npm install --only=dev
+
+${main_src}: package.json node_modules
+	npm run build
+	ls $@
+
+start: run/${runtime}
+
+${deploy_module_dir}/%: %
+	@echo "# TODO: minify: $<"
+	install -d ${@D}
+	install $< $@
+
+deploy: ${deploy_srcs}
+	ls $<

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/Blinkt.js');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/Blinkt",
   "scripts": {
     "test": "node example",
-    "build": "rimraf dist && babel ./src/*.js --out-dir dist",
+    "build": "rimraf dist && babel ./src/*.js --out-dir dist && babel ./example/*.js --out-dir dist/example",
     "eslint": "eslint ./src/**.js ./tests/**.js",
     "eslint-fix": "eslint --fix ./src/**.js"
   },

--- a/readme.md
+++ b/readme.md
@@ -54,14 +54,14 @@ targeting more constrained devices.
 First you need to install iotjs from source or precompiled package:
 
 * https://iotjs.net
-* https://s-opensource.org/2018/03/13/using-iotjs-raspberrypi0/
-* https://s-opensource.org/2018/04/20/iot-js-landed-raspbian/
-* https://github.com/rzr/webthing-iotjs/wiki
+* https://github.com/rzr/webthing-iotjs/wiki/IotJs
+* https://libraries.io/npm/wiringpi-iotjs
 
 Usage:
 
 ```sh
-make run/iotjs
+git clone --depth 1 https://github.com/Irrelon/node-blinkt ; cd node-blinkt
+make start
 ```
 
 [![iotjs-wiringpi](https://pbs.twimg.com/ext_tw_video_thumb/1019945702791766017/pu/img/bbbNf-HJR2FkUb5l.jpg)](https://twitter.com/TizenHelper/status/1019945989388546048# "blinkt-node")


### PR DESCRIPTION
Currently package.json is not parsed by IoT.js like Node.js,
so the index.js file will be used as entry point for module.

It was tested with:
iotjs-snapshot-0.0+1.0+515+g060bbdd6-0~rzr0+1.0+546+gad1de281

Change-Id: I90700b7af25bd13d2c6012692e34019adbee8eaf
Signed-off-by: Philippe Coval <p.coval@samsung.com>